### PR TITLE
Fix shipping prices on github pages

### DIFF
--- a/src/app/cart.service.ts
+++ b/src/app/cart.service.ts
@@ -21,7 +21,7 @@ export class CartService {
   }
 
   getShippingPrices() {
-    return this.http.get('/assets/shipping.json');
+    return this.http.get('./assets/shipping.json');
   }
 
   constructor(


### PR DESCRIPTION
This commit fixes the issue where the shipping prices would not appear on the github pages site.